### PR TITLE
Overhaul panic handling

### DIFF
--- a/examples/ping-pong/Cargo.lock
+++ b/examples/ping-pong/Cargo.lock
@@ -295,7 +295,7 @@ dependencies = [
  "num_cpus 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "signal-hook 0.1.0",
+ "signal-hook-shim 0.1.0",
 ]
 
 [[package]]
@@ -452,18 +452,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "signal-hook"
-version = "0.1.0"
-dependencies = [
- "signal-hook 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "signal-hook"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arc-swap 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "signal-hook-shim"
+version = "0.1.0"
+dependencies = [
+ "signal-hook 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/actor/tests/fail.rs
+++ b/src/actor/tests/fail.rs
@@ -1,0 +1,87 @@
+use crate::actor::*;
+use std::time::Duration;
+
+struct MyActor {
+    id: usize,
+    actor_ref: ActorRef<()>,
+}
+
+impl Actor<()> for MyActor {
+    fn receive(&mut self, _: (), _context: &mut ActorContext<()>) {
+        if self.id == 1 {
+            panic!();
+        }
+    }
+
+    fn receive_signal(&mut self, signal: Signal, _: &mut ActorContext<()>) {
+        match signal {
+            Signal::Started => {
+                if self.id == 0 {
+                    panic!();
+                }
+            }
+
+            Signal::Failed => {
+                self.actor_ref.tell(());
+            }
+
+            _ => (),
+        }
+    }
+}
+
+impl Drop for MyActor {
+    fn drop(&mut self) {
+        if self.id == 2 {
+            self.actor_ref.tell(());
+        }
+    }
+}
+
+#[test]
+fn test() {
+    struct TestReaper;
+
+    impl Actor<()> for TestReaper {
+        fn receive(&mut self, _: (), _: &mut ActorContext<()>) {}
+
+        fn receive_signal(&mut self, signal: Signal, ctx: &mut ActorContext<()>) {
+            if let Signal::Started = signal {
+                let mut probe = ctx.spawn_probe::<()>();
+
+                // 0 panics during startup
+                ctx.spawn(MyActor {
+                    id: 0,
+                    actor_ref: probe.actor_ref.clone(),
+                });
+
+                assert_eq!(probe.receive(Duration::from_secs(10)), ());
+
+                // 1 panics after receiving a message
+                let one = ctx.spawn(MyActor {
+                    id: 1,
+                    actor_ref: probe.actor_ref.clone(),
+                });
+
+                one.tell(());
+
+                assert_eq!(probe.receive(Duration::from_secs(10)), ());
+
+                // 2 messages in its drop method
+
+                let two = ctx.spawn(MyActor {
+                    id: 2,
+                    actor_ref: probe.actor_ref.clone(),
+                });
+
+                two.stop();
+
+                assert_eq!(probe.receive(Duration::from_secs(10)), ());
+
+                ctx.actor_ref().stop();
+            }
+        }
+    }
+
+    assert!(ActorSystem::new().spawn(TestReaper).is_ok());
+}

--- a/src/actor/tests/mod.rs
+++ b/src/actor/tests/mod.rs
@@ -1,5 +1,6 @@
 mod convert;
 mod drain;
+mod fail;
 
 #[cfg(feature = "posix-signals-support")]
 mod posix_signals;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use crate::dispatcher::Thunk;
+use crate::dispatcher::{BoxedFn, Thunk};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -46,13 +46,13 @@ impl<A> MaybeCancelled<A> {
 }
 
 pub struct Deferred {
-    thunk: Option<Thunk>,
+    thunk: Option<Box<BoxedFn + 'static>>,
 }
 
 impl Deferred {
     pub fn new<F: FnOnce()>(f: F) -> Self
     where
-        F: 'static + Send,
+        F: 'static,
     {
         Self {
             thunk: Some(Box::new(f)),


### PR DESCRIPTION
Don't rely on catch_unwind. Instead, we use deferred to check for thread
panicking and message ourselves a Stop(fail = true) if that's the case.

In general, note that panics should be avoided, but sometimes unforseen
things happen hence it's necessary to consider them in Pantomime.

Supervisor and Streams still need to be extended to use this mechanism,
that will happen in a separate commit.