### PR TITLE
Implement `ActorContext::stop` and `ActorContext::fail` 

### DIFF
--- a/src/actor/actor_ref.rs
+++ b/src/actor/actor_ref.rs
@@ -407,6 +407,10 @@ impl SystemActorRef {
         self.inner.id()
     }
 
+    pub fn fail(&self) {
+        self.inner.fail();
+    }
+
     pub fn stop(&self) {
         self.inner.stop();
     }
@@ -475,6 +479,10 @@ where
         self.inner.tell_cancellable(cancellable, msg, thunk);
     }
 
+    pub fn fail(&self) {
+        self.inner.fail();
+    }
+
     pub fn stop(&self) {
         self.inner.stop();
     }
@@ -508,6 +516,10 @@ where
 
     fn id(&self) -> usize {
         self.inner.id()
+    }
+
+    fn fail(&self) {
+        self.inner.fail();
     }
 
     fn stop(&self) {
@@ -856,6 +868,8 @@ where
 pub(in crate::actor) trait SystemActorRefInner: Downcast {
     fn clone_box(&self) -> Box<SystemActorRefInner + Send + Sync>;
 
+    fn fail(&self);
+
     fn stop(&self);
 
     fn id(&self) -> usize;
@@ -901,6 +915,10 @@ where
             state: self.state.clone(),
             mailbox_appender: self.mailbox_appender.clone(),
         })
+    }
+
+    fn fail(&self) {
+        self.tell_system(SystemMsg::Stop(true));
     }
 
     fn stop(&self) {
@@ -954,6 +972,10 @@ where
         })
     }
 
+    fn fail(&self) {
+        self.inner.fail();
+    }
+
     fn stop(&self) {
         self.inner.stop();
     }
@@ -997,6 +1019,8 @@ impl SystemActorRefInner for EmptyActorRefCell {
     fn clone_box(&self) -> Box<SystemActorRefInner + Send + Sync> {
         Box::new(EmptyActorRefCell)
     }
+
+    fn fail(&self) {}
 
     fn stop(&self) {}
 

--- a/src/actor/system.rs
+++ b/src/actor/system.rs
@@ -106,6 +106,7 @@ impl ActorSystemContext {
                 children: HashMap::new(),
                 deliveries: HashMap::new(),
                 dispatcher: dispatcher.clone(),
+                pending_stop: None,
                 system_context: self.clone(),
             },
             dispatcher,

--- a/src/actor/tests/fail.rs
+++ b/src/actor/tests/fail.rs
@@ -3,13 +3,23 @@ use std::time::Duration;
 
 struct MyActor {
     id: usize,
-    actor_ref: ActorRef<()>,
+    actor_ref: ActorRef<usize>,
 }
 
 impl Actor<()> for MyActor {
-    fn receive(&mut self, _: (), _context: &mut ActorContext<()>) {
+    fn receive(&mut self, _: (), context: &mut ActorContext<()>) {
         if self.id == 1 {
             panic!();
+        } else if self.id == 4 {
+            self.id = 40;
+
+            // the reaper sent a few messages, so what we're testing
+            // here is that context.fail is received but those
+            // other messages are not
+
+            context.fail();
+        } else if self.id == 40 {
+            self.actor_ref.tell(1);
         }
     }
 
@@ -22,7 +32,7 @@ impl Actor<()> for MyActor {
             }
 
             Signal::Failed => {
-                self.actor_ref.tell(());
+                self.actor_ref.tell(0);
             }
 
             _ => (),
@@ -33,7 +43,7 @@ impl Actor<()> for MyActor {
 impl Drop for MyActor {
     fn drop(&mut self) {
         if self.id == 2 {
-            self.actor_ref.tell(());
+            self.actor_ref.tell(0);
         }
     }
 }
@@ -47,7 +57,7 @@ fn test() {
 
         fn receive_signal(&mut self, signal: Signal, ctx: &mut ActorContext<()>) {
             if let Signal::Started = signal {
-                let mut probe = ctx.spawn_probe::<()>();
+                let mut probe = ctx.spawn_probe::<usize>();
 
                 // 0 panics during startup
                 ctx.spawn(MyActor {
@@ -55,7 +65,7 @@ fn test() {
                     actor_ref: probe.actor_ref().clone(),
                 });
 
-                assert_eq!(probe.receive(Duration::from_secs(10)), ());
+                assert_eq!(probe.receive(Duration::from_secs(10)), 0);
 
                 // 1 panics after receiving a message
                 let one = ctx.spawn(MyActor {
@@ -65,7 +75,7 @@ fn test() {
 
                 one.tell(());
 
-                assert_eq!(probe.receive(Duration::from_secs(10)), ());
+                assert_eq!(probe.receive(Duration::from_secs(10)), 0);
 
                 // 2 messages in its drop method
 
@@ -76,7 +86,7 @@ fn test() {
 
                 two.stop();
 
-                assert_eq!(probe.receive(Duration::from_secs(10)), ());
+                assert_eq!(probe.receive(Duration::from_secs(10)), 0);
 
                 // 3 is failed from the outside
 
@@ -87,7 +97,22 @@ fn test() {
 
                 three.fail();
 
-                assert_eq!(probe.receive(Duration::from_secs(10)), ());
+                assert_eq!(probe.receive(Duration::from_secs(10)), 0);
+
+                // 4 fails from inside (testing message order)
+
+                let four = ctx.spawn(MyActor {
+                    id: 4,
+                    actor_ref: probe.actor_ref().clone(),
+                });
+
+                four.tell(());
+                four.tell(()); // shouldn't be received
+                four.tell(()); // shouldn't be received
+                four.tell(()); // shouldn't be received
+
+                assert_eq!(probe.receive(Duration::from_secs(10)), 0);
+
                 ctx.actor_ref().stop();
             }
         }

--- a/src/actor/tests/fail.rs
+++ b/src/actor/tests/fail.rs
@@ -78,6 +78,16 @@ fn test() {
 
                 assert_eq!(probe.receive(Duration::from_secs(10)), ());
 
+                // 3 is failed from the outside
+
+                let three = ctx.spawn(MyActor {
+                    id: 3,
+                    actor_ref: probe.actor_ref().clone(),
+                });
+
+                three.fail();
+
+                assert_eq!(probe.receive(Duration::from_secs(10)), ());
                 ctx.actor_ref().stop();
             }
         }


### PR DESCRIPTION
Given a mutable borrow to an `ActorContext` -- i.e. you're in
`Actor::receive` or `Actor::receive_context`, this allows immediate
stopping or failing of the actor.

This contrasts with `ActorRef::stop` and `ActorRef::fail` where they are
enqueued like regular messages.

Basically, from the inside, you can stop yourself (effectively)
immediately, whereas from the outside you don't have control over the
message ordering.