### PR TITLE
Rewrite the `FutureDispatcherBridge`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ futures = { version = "0.1", optional = true }
 log = "0.4"
 mio = { version = "0.6", optional = true }
 num_cpus = "1.0"
-parking_lot = "0.7"
 rand = "0.6"
 
 # FIXME: cannot conditionally enable features depending upon platform

--- a/examples/http-hyper/Cargo.lock
+++ b/examples/http-hyper/Cargo.lock
@@ -419,9 +419,8 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "signal-hook 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signal-hook-shim 0.1.0",
  "tokio 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -600,6 +599,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arc-swap 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "signal-hook-shim"
+version = "0.1.0"
+dependencies = [
+ "signal-hook 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@ extern crate atty;
 extern crate chrono;
 extern crate crossbeam;
 extern crate fern;
-extern crate parking_lot;
 extern crate rand;
 
 #[macro_use]


### PR DESCRIPTION
Per title. Interestingly, this with Pantomime's Tokio executor runs [Hyper](https://hyper.rs/) about 15% faster than regular Tokio. Flawed microbenchmark, but at least it shows that the implementation is pretty efficient.

Fixes #8 