### PR TITLE
streams: Initial UDP support (again)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ rust:
 os:
   - linux
   - osx
-  - windows
+    #- windows

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ crossbeam = "0.7.1"
 downcast-rs = "1.0.3"
 fern = { version = "0.5", features = ["colored"] }
 log = "0.4"
-mio = "0.6"
+mio = "0.6.19"
 num_cpus = "1.0"
 parking_lot = "0.8"
 rand = "0.6"

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -16,7 +16,7 @@ pub use self::actor_ref::{
     Signal, Spawnable, StopReason, SystemActorRef, Watchable,
 };
 pub use self::probe::{Probe, SpawnProbe};
-pub use self::system::{ActiveActorSystem, ActorSystem, ActorSystemContext};
+pub use self::system::{ActiveActorSystem, ActorSystem, ActorSystemContext, SubscriptionEvent};
 
 #[cfg(all(feature = "posix-signals-support"))]
 pub(self) use self::actor_ref::SystemMsg;

--- a/src/actor/system.rs
+++ b/src/actor/system.rs
@@ -27,7 +27,7 @@ const MIO_TOKEN_SENDER: usize = 1;
 #[cfg(feature = "posix-signals-support")]
 const MIO_TOKEN_POSIX_SIGNALS: usize = 2;
 
-pub(crate) enum SubscriptionEvent {
+pub enum SubscriptionEvent {
     Ready(Arc<Poll>, usize),
     MioEvent(Event),
 }
@@ -153,12 +153,10 @@ impl ActorSystemContext {
         actor_ref
     }
 
-    #[allow(dead_code)]
     pub(crate) fn subscribe(&self, actor_ref: ActorRef<SubscriptionEvent>) {
         self.send(ActorSystemMsg::Subscribe(actor_ref));
     }
 
-    #[allow(dead_code)]
     pub(crate) fn unsubscribe(&self, token: usize) {
         self.send(ActorSystemMsg::Unsubscribe(token));
     }

--- a/src/stream/flow/delay.rs
+++ b/src/stream/flow/delay.rs
@@ -69,17 +69,17 @@ impl<A: Send> Logic<A, A> for Delay {
 
                 State::Waiting => Action::Complete(None),
 
-                State::Stopping => Action::None,
+                State::Stopping => Action::Complete(None),
             },
 
-            LogicEvent::Cancelled => Action::Complete(None),
+            LogicEvent::Cancelled => Action::Cancel,
 
             LogicEvent::Forwarded(DelayMsg::Ready(element)) => {
-                self.state = State::Waiting;
-
                 if let State::Stopping = self.state {
                     Action::PushAndComplete(element, None)
                 } else {
+                    self.state = State::Waiting;
+
                     Action::Push(element)
                 }
             }

--- a/src/stream/flow/filter.rs
+++ b/src/stream/flow/filter.rs
@@ -26,8 +26,6 @@ impl<A: Send, F: FnMut(&A) -> bool + Send> Logic<A, A> for Filter<F> {
         _: &mut StreamContext<A, A, Self::Ctl>,
     ) -> Action<A, Self::Ctl> {
         match msg {
-            LogicEvent::Pulled => Action::Pull,
-
             LogicEvent::Pushed(element) => {
                 if (self.filter)(&element) {
                     Action::Push(element)
@@ -36,9 +34,11 @@ impl<A: Send, F: FnMut(&A) -> bool + Send> Logic<A, A> for Filter<F> {
                 }
             }
 
-            LogicEvent::Stopped | LogicEvent::Cancelled => Action::Complete(None),
-
-            LogicEvent::Started | LogicEvent::Forwarded(()) => Action::None,
+            LogicEvent::Pulled => Action::Pull,
+            LogicEvent::Cancelled => Action::Cancel,
+            LogicEvent::Stopped => Action::Complete(None),
+            LogicEvent::Started => Action::None,
+            LogicEvent::Forwarded(()) => Action::None,
         }
     }
 }

--- a/src/stream/flow/identity.rs
+++ b/src/stream/flow/identity.rs
@@ -23,11 +23,9 @@ impl<A: Send> Logic<A, A> for Identity {
     ) -> Action<A, Self::Ctl> {
         match msg {
             LogicEvent::Pulled => Action::Pull,
-
             LogicEvent::Pushed(element) => Action::Push(element),
-
-            LogicEvent::Stopped | LogicEvent::Cancelled => Action::Complete(None),
-
+            LogicEvent::Cancelled => Action::Cancel,
+            LogicEvent::Stopped => Action::Complete(None),
             LogicEvent::Started | LogicEvent::Forwarded(()) => Action::None,
         }
     }

--- a/src/stream/flow/map.rs
+++ b/src/stream/flow/map.rs
@@ -27,12 +27,11 @@ impl<A: Send, B: Send, F: FnMut(A) -> B + Send> Logic<A, B> for Map<F> {
     ) -> Action<B, Self::Ctl> {
         match msg {
             LogicEvent::Pulled => Action::Pull,
-
             LogicEvent::Pushed(element) => Action::Push((self.map)(element)),
-
-            LogicEvent::Stopped | LogicEvent::Cancelled => Action::Complete(None),
-
-            LogicEvent::Started | LogicEvent::Forwarded(()) => Action::None,
+            LogicEvent::Cancelled => Action::Cancel,
+            LogicEvent::Stopped => Action::Complete(None),
+            LogicEvent::Started => Action::None,
+            LogicEvent::Forwarded(()) => Action::None,
         }
     }
 }

--- a/src/stream/flow/scan.rs
+++ b/src/stream/flow/scan.rs
@@ -55,9 +55,10 @@ impl<A: Send, B: Clone + Send, F: FnMut(B, A) -> B + Send> Logic<A, B> for Scan<
                 Action::Push(last)
             }
 
-            LogicEvent::Stopped | LogicEvent::Cancelled => Action::Complete(None),
-
-            LogicEvent::Started | LogicEvent::Forwarded(()) => Action::None,
+            LogicEvent::Cancelled => Action::Cancel,
+            LogicEvent::Stopped => Action::Complete(None),
+            LogicEvent::Started => Action::None,
+            LogicEvent::Forwarded(()) => Action::None,
         }
     }
 }

--- a/src/stream/flow/take_while.rs
+++ b/src/stream/flow/take_while.rs
@@ -26,8 +26,6 @@ impl<A: Send, F: FnMut(&A) -> bool + Send> Logic<A, A> for TakeWhile<F> {
         _: &mut StreamContext<A, A, Self::Ctl>,
     ) -> Action<A, Self::Ctl> {
         match msg {
-            LogicEvent::Pulled => Action::Pull,
-
             LogicEvent::Pushed(element) => {
                 if (self.while_fn)(&element) {
                     Action::Push(element)
@@ -36,9 +34,11 @@ impl<A: Send, F: FnMut(&A) -> bool + Send> Logic<A, A> for TakeWhile<F> {
                 }
             }
 
-            LogicEvent::Stopped | LogicEvent::Cancelled => Action::Complete(None),
-
-            LogicEvent::Started | LogicEvent::Forwarded(()) => Action::None,
+            LogicEvent::Pulled => Action::Pull,
+            LogicEvent::Cancelled => Action::Cancel,
+            LogicEvent::Stopped => Action::Complete(None),
+            LogicEvent::Started => Action::None,
+            LogicEvent::Forwarded(()) => Action::None,
         }
     }
 }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1,4 +1,4 @@
-use crate::actor::{ActorContext, ActorRef, FailureReason};
+use crate::actor::{ActorContext, ActorRef, FailureReason, SubscriptionEvent};
 use crate::stream::internal::{InternalStreamCtl, RunnableStream, StageMsg};
 use crossbeam::atomic::AtomicCell;
 use std::collections::VecDeque;
@@ -179,7 +179,7 @@ where
     Out: 'static + Send,
     Ctl: 'static + Send,
 {
-    fn schedule_delivery<S: AsRef<str>>(&mut self, name: S, timeout: Duration, msg: Ctl) {
+    pub fn schedule_delivery<S: AsRef<str>>(&mut self, name: S, timeout: Duration, msg: Ctl) {
         match self.ctx {
             StreamContextType::Fused(ref mut actions, _) => {
                 actions.push_back(StreamContextAction::ScheduleDelivery(
@@ -195,7 +195,7 @@ where
         }
     }
 
-    fn stage_ref(&mut self) -> StageRef<Ctl> {
+    pub fn stage_ref(&mut self) -> StageRef<Ctl> {
         match self.ctx {
             StreamContextType::Fused(_, ref stage_ref) => StageRef {
                 actor_ref: stage_ref.actor_ref.clone(),
@@ -209,7 +209,7 @@ where
         }
     }
 
-    fn tell(&mut self, action: Action<Out, Ctl>) {
+    pub fn tell(&mut self, action: Action<Out, Ctl>) {
         match self.ctx {
             StreamContextType::Fused(ref mut actions, _) => {
                 actions.push_back(StreamContextAction::Action(action));
@@ -219,6 +219,14 @@ where
                 ctx.actor_ref().tell(StageMsg::Action(action));
             }
         }
+    }
+
+    pub(crate) fn subscribe(&self, actor_ref: ActorRef<SubscriptionEvent>) {
+        unimplemented!()
+    }
+
+    pub(crate) fn unsubscribe(&self, token: usize) {
+        unimplemented!()
     }
 }
 

--- a/src/stream/sink/udp.rs
+++ b/src/stream/sink/udp.rs
@@ -1,0 +1,210 @@
+use crate::actor::SubscriptionEvent;
+use crate::stream::{Action, Datagram, Logic, LogicEvent, StreamContext};
+use mio::{net::UdpSocket, Poll, PollOpt, Ready, Token};
+use std::io::{ErrorKind as IoErrorKind, Result as IoResult};
+use std::sync::Arc;
+
+struct Chunk {
+    data: Datagram,
+    written: usize,
+}
+
+pub struct Udp {
+    socket: IoResult<UdpSocket>,
+    chunk: Option<Chunk>,
+    ready: bool,
+    poll: Option<Arc<Poll>>,
+    token: usize,
+    pulled: bool,
+    stopped: bool,
+}
+impl Udp {
+    pub fn new(socket: &UdpSocket) -> Self {
+        Self {
+            socket: socket.try_clone(),
+            chunk: None,
+            ready: false,
+            poll: None,
+            token: 0,
+            pulled: false,
+            stopped: false,
+        }
+    }
+
+    fn complete(&self) -> Action<(), SubscriptionEvent> {
+        if self.pulled {
+            Action::PushAndComplete((), None)
+        } else {
+            Action::Complete(None)
+        }
+    }
+
+    fn try_write(
+        &mut self,
+        ctx: &mut StreamContext<Datagram, (), SubscriptionEvent>,
+    ) -> Action<(), SubscriptionEvent> {
+        match (&mut self.socket, &mut self.chunk) {
+            (Ok(ref mut s), Some(ref mut chunk)) if self.ready => {
+                match s.send_to(&chunk.data.data[chunk.written..], &chunk.data.address) {
+                    Ok(bytes_written) => {
+                        println!("wrote {}", bytes_written);
+                        chunk.written += bytes_written;
+
+                        if chunk.written == chunk.data.data.len() {
+                            self.chunk = None;
+
+                            if self.stopped {
+                                self.unregister(ctx);
+                                self.complete()
+                            } else {
+                                Action::Pull
+                            }
+                        } else {
+                            Action::None
+                        }
+                    }
+
+                    Err(e) if e.kind() == IoErrorKind::WouldBlock => {
+                        println!("would block");
+                        self.ready = false;
+
+                        Action::None
+                    }
+
+                    Err(_e) => {
+                        // @TODO
+                        unimplemented!()
+                    }
+                }
+            }
+
+            _ => Action::None,
+        }
+    }
+
+    fn unregister(&mut self, ctx: &mut StreamContext<Datagram, (), SubscriptionEvent>) {
+        if let Some(poll) = self.poll.take() {
+            if let Ok(ref socket) = self.socket {
+                // @TODO expect doesn't seem appropriate
+
+                poll.deregister(socket)
+                    .expect("pantomime bug: failed to deregister socket");
+            }
+        }
+
+        if self.token > 0 {
+            ctx.unsubscribe(self.token);
+
+            self.token = 0;
+        }
+    }
+}
+
+impl Logic<Datagram, ()> for Udp {
+    type Ctl = SubscriptionEvent;
+
+    fn name(&self) -> &'static str {
+        "pantomime::stream::sink::Udp"
+    }
+
+    fn buffer_size(&self) -> Option<usize> {
+        Some(0)
+    }
+
+    fn fusible(&self) -> bool {
+        false
+    }
+
+    fn receive(
+        &mut self,
+        msg: LogicEvent<Datagram, Self::Ctl>,
+        ctx: &mut StreamContext<Datagram, (), Self::Ctl>,
+    ) -> Action<(), Self::Ctl> {
+        match msg {
+            LogicEvent::Pushed(data) => {
+                if self.chunk.is_some() {
+                    panic!("TODO");
+                }
+                println!("got some data ready={:?}", self.ready);
+
+                self.chunk = Some(Chunk { data, written: 0 });
+
+                self.try_write(ctx)
+            }
+
+            LogicEvent::Forwarded(SubscriptionEvent::MioEvent(event)) => {
+                println!("sink got an mio event");
+                if event.readiness().is_writable() {
+                    println!("is writable");
+                    self.ready = true;
+
+                    self.try_write(ctx)
+                } else {
+                    Action::None
+                }
+            }
+
+            LogicEvent::Forwarded(SubscriptionEvent::Ready(poll, token)) => {
+                println!("sink is ready");
+                match self.socket {
+                    Ok(ref socket) => {
+                        println!("registering the socket (token={})", token);
+                        // @TODO expect doesn't seem appropriate
+                        poll.register(socket, Token(token), Ready::writable(), PollOpt::edge())
+                            .expect("pantomime bug: failed to register socket");
+
+                        self.poll = Some(poll);
+                        self.token = token;
+
+                        Action::None
+                    }
+
+                    Err(ref _e) => {
+                        println!("ERRRR");
+                        // shouldn't happen
+
+                        ctx.unsubscribe(token);
+
+                        Action::None
+                    }
+                }
+            }
+
+            LogicEvent::Started => {
+                let actor_ref = ctx.stage_ref().actor_ref.clone();
+
+                println!("sink subscribing for id={}", actor_ref.id());
+
+                println!("messaging self");
+
+                ctx.subscribe(actor_ref);
+
+                Action::None
+            }
+
+            LogicEvent::Pulled => {
+                self.pulled = true;
+                println!("will pull");
+
+                Action::Pull
+            }
+
+            LogicEvent::Stopped => {
+                self.stopped = true;
+
+                if self.chunk.is_none() {
+                    self.unregister(ctx);
+                    self.complete()
+                } else {
+                    Action::None
+                }
+            }
+
+            LogicEvent::Cancelled => {
+                self.chunk = None;
+                self.unregister(ctx);
+                self.complete()
+            }
+        }
+    }
+}

--- a/src/stream/source/mod.rs
+++ b/src/stream/source/mod.rs
@@ -9,11 +9,13 @@ mod iterator;
 mod merge;
 mod queue;
 mod repeat;
+mod udp;
 
 pub use iterator::Iterator;
 //pub use merge::Merge;
 //pub use queue::SourceQueue;
 pub use repeat::Repeat;
+pub use udp::Udp;
 
 pub struct Source<A> {
     pub(in crate::stream) producers: Vec<LogicType<(), A>>,

--- a/src/stream/source/mod.rs
+++ b/src/stream/source/mod.rs
@@ -1,7 +1,7 @@
 use crate::stream::internal::{ContainedLogicImpl, LogicType, SourceLike, UnionLogic};
 use crate::stream::sink::Sink;
 use crate::stream::{flow, flow::Flow, flow::Fused};
-use crate::stream::{Logic, Stream};
+use crate::stream::{Datagram, Logic, Stream};
 use std::iter::Iterator as Iter;
 use std::marker::PhantomData;
 
@@ -9,12 +9,14 @@ mod iterator;
 mod merge;
 mod queue;
 mod repeat;
+mod single;
 mod udp;
 
 pub use iterator::Iterator;
 //pub use merge::Merge;
 //pub use queue::SourceQueue;
 pub use repeat::Repeat;
+pub use single::Single;
 pub use udp::Udp;
 
 pub struct Source<A> {
@@ -58,6 +60,10 @@ where
         A: Clone,
     {
         Self::new(Repeat::new(element))
+    }
+
+    pub fn single(element: A) -> Self {
+        Self::new(Single::new(element))
     }
 
     pub fn to<Out>(self, sink: Sink<A, Out>) -> Stream<Out>
@@ -164,5 +170,11 @@ where
                 .pop()
                 .expect("pantomime bug: Source::producers is empty")
         }
+    }
+}
+
+impl Source<Datagram> {
+    pub fn udp(socket: &mio::net::UdpSocket) -> Self {
+        Self::new(Udp::new(socket))
     }
 }

--- a/src/stream/source/single.rs
+++ b/src/stream/source/single.rs
@@ -1,0 +1,49 @@
+use crate::stream::{Action, Logic, LogicEvent, StreamContext};
+
+pub struct Single<A>
+where
+    A: 'static,
+{
+    element: Option<A>,
+}
+
+impl<A> Single<A>
+where
+    A: 'static + Send,
+{
+    pub fn new(element: A) -> Self {
+        Self {
+            element: Some(element),
+        }
+    }
+}
+
+impl<A> Logic<(), A> for Single<A>
+where
+    A: 'static + Send,
+{
+    type Ctl = ();
+
+    fn name(&self) -> &'static str {
+        "Single"
+    }
+
+    fn receive(
+        &mut self,
+        msg: LogicEvent<(), Self::Ctl>,
+        _: &mut StreamContext<(), A, Self::Ctl>,
+    ) -> Action<A, Self::Ctl> {
+        match msg {
+            LogicEvent::Pulled => {
+                Action::PushAndComplete(self.element.take().expect("Single::element is None"), None)
+            }
+
+            LogicEvent::Cancelled => Action::Complete(None),
+
+            LogicEvent::Pushed(())
+            | LogicEvent::Stopped
+            | LogicEvent::Started
+            | LogicEvent::Forwarded(()) => Action::None,
+        }
+    }
+}

--- a/src/stream/source/udp.rs
+++ b/src/stream/source/udp.rs
@@ -1,0 +1,147 @@
+use crate::actor::SubscriptionEvent;
+use crate::stream::{Action, Logic, LogicEvent, StreamContext};
+use mio::{net::UdpSocket, Poll, PollOpt, Ready, Token};
+use std::io::{ErrorKind as IoErrorKind, Result as IoResult};
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+pub struct Datagram {
+    pub data: Vec<u8>,
+    pub address: SocketAddr
+}
+
+pub struct Udp {
+    socket: IoResult<UdpSocket>,
+    buffer: Vec<u8>,
+    ready: bool,
+    waiting: bool,
+    poll: Option<Arc<Poll>>,
+    token: usize,
+}
+
+impl Udp {
+    pub fn new(address: &SocketAddr) -> Self {
+        Self {
+            socket: UdpSocket::bind(address),
+            buffer: vec![0; 8192], // @TODO
+            ready: false,
+            waiting: false,
+            poll: None,
+            token: 0
+        }
+    }
+
+    fn try_read(&mut self) -> Action<Datagram, SubscriptionEvent> {
+        match self.socket {
+            Ok(ref mut s) if self.ready && self.waiting => {
+                match s.recv_from(&mut self.buffer) {
+                    Ok((bytes_read, socket_addr)) => {
+                        self.waiting = false;
+
+                        Action::Push(Datagram {
+                            data: self.buffer[0..bytes_read].to_vec(),
+                            address: socket_addr
+                        })
+                    }
+
+                    Err(e) if e.kind() == IoErrorKind::WouldBlock => {
+                        self.ready = false;
+
+                        Action::None
+                    }
+
+                    Err(_e) => {
+                        // @TODO
+                        unimplemented!()
+                    }
+                }
+            }
+
+            _ => {
+                Action::None
+            }
+        }
+    }
+}
+
+impl Logic<(), Datagram> for Udp {
+    type Ctl = SubscriptionEvent;
+
+    fn name(&self) -> &'static str {
+        "Udp"
+    }
+
+    fn buffer_size(&self) -> Option<usize> {
+        Some(0)
+    }
+
+    fn fusible(&self) -> bool {
+        false
+    }
+
+    fn receive(
+        &mut self,
+        msg: LogicEvent<(), Self::Ctl>,
+        ctx: &mut StreamContext<(), Datagram, Self::Ctl>,
+    ) -> Action<Datagram, Self::Ctl> {
+        match msg {
+            LogicEvent::Pulled => {
+                self.waiting = true;
+
+                self.try_read()
+            }
+
+            LogicEvent::Forwarded(SubscriptionEvent::MioEvent(event)) => {
+                if event.readiness().is_readable() {
+                    self.ready = true;
+
+                    self.try_read()
+                } else {
+                    Action::None
+                }
+            }
+
+            LogicEvent::Forwarded(SubscriptionEvent::Ready(poll, token)) => {
+                match self.socket {
+                    Ok(ref socket) => {
+                        // @TODO expect doesn't seem appropriate
+                        poll.register(
+                            socket,
+                            Token(token),
+                            Ready::readable(),
+                            PollOpt::edge(),
+                        )
+                        .expect("pantomime bug: failed to register socket");
+
+                        self.poll = Some(poll);
+                        self.token = token;
+
+                        Action::None
+                    }
+
+                    Err(ref _e) => {
+                        // shouldn't happen
+
+                        ctx.unsubscribe(token);
+
+                        Action::None
+                    }
+                }
+            }
+
+            LogicEvent::Started => {
+                let actor_ref = ctx.stage_ref().actor_ref.clone();
+
+                ctx.subscribe(actor_ref);
+
+                Action::None
+            }
+
+            LogicEvent::Cancelled => {
+                unimplemented!()
+            }
+
+            LogicEvent::Pushed(()) | LogicEvent::Stopped => Action::None,
+        }
+    }
+}

--- a/src/stream/tests/mod.rs
+++ b/src/stream/tests/mod.rs
@@ -1,2 +1,3 @@
 mod context_stage_ref;
 mod legacy;
+mod udp;

--- a/src/stream/tests/udp.rs
+++ b/src/stream/tests/udp.rs
@@ -1,0 +1,47 @@
+use crate::stream::*;
+use mio::net::UdpSocket;
+use std::str;
+
+#[test]
+fn basic_test() {
+    use crate::actor::*;
+    use crate::stream::{Sink, Source};
+
+    struct TestReaper;
+
+    impl TestReaper {
+        fn new() -> Self {
+            Self
+        }
+    }
+
+    impl Actor for TestReaper {
+        type Msg = Option<Datagram>;
+
+        fn receive(&mut self, msg: Self::Msg, ctx: &mut ActorContext<Self::Msg>) {
+            let msg = msg.unwrap();
+            let msg = str::from_utf8(&msg.data).unwrap();
+
+            assert_eq!(msg, "12345");
+
+            ctx.stop();
+        }
+
+        fn receive_signal(&mut self, signal: Signal, ctx: &mut ActorContext<Self::Msg>) {
+            if let Signal::Started = signal {
+                let socket = UdpSocket::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+                let addr = socket.local_addr().unwrap();
+                let source = Source::udp(&socket);
+
+                let (_, result) = ctx.spawn(source.to(Sink::first()));
+                ctx.watch(result, |value| value);
+
+                let _ = ctx.spawn(
+                    Source::single(Datagram::new(b"12345".to_vec(), addr)).to(Sink::udp(&socket)),
+                );
+            }
+        }
+    }
+
+    assert!(ActorSystem::new().spawn(TestReaper::new()).is_ok());
+}


### PR DESCRIPTION
This implements UDP support via a `Source::udp` and `Sink::udp`. These can be used to receive data from (source) and send data to (sink) remote computers.

We're not fully featured yet, but at this stage in the project I'd rather merge things early.

This also fixes up some semantics around stream cancellation. When downstream cancels, it's now simply delivered as an event to the midstream logic. At the most upstream stage, a cancel emits a complete which cascades downwards. Each stage is responsible for carrying that cancellation signal upwards, but by deferring this to the logic, it makes more interesting logic implementations possible.