### PR TITLE
stream: Implement SourceQueue

### DIFF
--- a/src/prelude/mod.rs
+++ b/src/prelude/mod.rs
@@ -8,3 +8,4 @@ pub use crate::actor::{
 };
 pub use crate::cfg::Config;
 pub use crate::dispatcher::*;
+pub use crate::stream::{Flow, Sink, Source};

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -40,13 +40,6 @@ impl Datagram {
     }
 }
 
-pub enum PortAction<A> {
-    Cancel,
-    Complete(Option<FailureReason>),
-    Pull,
-    Push(A),
-}
-
 pub enum LogicEvent<A, Msg> {
     Pulled,
     Pushed(A),
@@ -62,6 +55,24 @@ pub enum LogicPortEvent<A> {
     Started(usize),
     Stopped(usize),
     Cancelled(usize),
+}
+
+// @TODO add backpressure, fail
+pub enum OverflowStrategy {
+    DropNewest,
+    DropOldest,
+}
+
+pub enum PortAction<A> {
+    Cancel,
+    Complete(Option<FailureReason>),
+    Pull,
+    Push(A),
+}
+
+pub enum PushResult {
+    Pushed,
+    Dropped,
 }
 
 /// All stages are backed by a particular `Logic` that defines
@@ -263,7 +274,7 @@ pub enum StreamCtl {
     Fail,
 }
 
-struct StreamComplete<Out>
+pub struct StreamComplete<Out>
 where
     Out: 'static + Send,
 {

--- a/src/stream/sink/mod.rs
+++ b/src/stream/sink/mod.rs
@@ -1,19 +1,12 @@
 use crate::stream::internal::{ContainedLogicImpl, IndividualLogic, LogicType};
 use crate::stream::{Datagram, Logic};
 
-mod collect;
-mod first;
-mod for_each;
-mod ignore;
-mod last;
-mod udp;
-
-pub use collect::Collect;
-pub use first::First;
-pub use for_each::ForEach;
-pub use ignore::Ignore;
-pub use last::Last;
-pub use udp::Udp;
+pub mod collect;
+pub mod first;
+pub mod for_each;
+pub mod ignore;
+pub mod last;
+pub mod udp;
 
 /// A `Sink` is a stage that accepts a single output, and outputs a
 /// terminal value.
@@ -66,11 +59,11 @@ where
     A: Send,
 {
     pub fn first() -> Self {
-        Sink::new(First::new())
+        Sink::new(first::First::new())
     }
 
     pub fn last() -> Self {
-        Sink::new(Last::new())
+        Sink::new(last::Last::new())
     }
 }
 
@@ -82,11 +75,11 @@ where
     where
         F: 'static + Send,
     {
-        Sink::new(ForEach::new(for_each_fn))
+        Sink::new(for_each::ForEach::new(for_each_fn))
     }
 
     pub fn ignore() -> Self {
-        Sink::new(Ignore::new())
+        Sink::new(ignore::Ignore::new())
     }
 }
 
@@ -95,12 +88,12 @@ where
     A: Send,
 {
     pub fn collect() -> Self {
-        Sink::new(Collect::new())
+        Sink::new(collect::Collect::new())
     }
 }
 
 impl Sink<Datagram, ()> {
     pub fn udp(socket: &mio::net::UdpSocket) -> Self {
-        Self::new(Udp::new(socket))
+        Self::new(udp::Udp::new(socket))
     }
 }

--- a/src/stream/sink/udp.rs
+++ b/src/stream/sink/udp.rs
@@ -47,7 +47,7 @@ impl Udp {
             (Ok(ref mut s), Some(ref mut chunk)) if self.ready => {
                 match s.send_to(&chunk.data.data[chunk.written..], &chunk.data.address) {
                     Ok(bytes_written) => {
-                        println!("wrote {}", bytes_written);
+                        //println!("wrote {}", bytes_written);
                         chunk.written += bytes_written;
 
                         if chunk.written == chunk.data.data.len() {
@@ -65,7 +65,7 @@ impl Udp {
                     }
 
                     Err(e) if e.kind() == IoErrorKind::WouldBlock => {
-                        println!("would block");
+                        //println!("would block");
                         self.ready = false;
 
                         Action::None
@@ -125,7 +125,7 @@ impl Logic<Datagram, ()> for Udp {
                 if self.chunk.is_some() {
                     panic!("TODO");
                 }
-                println!("got some data ready={:?}", self.ready);
+                //println!("got some data ready={:?}", self.ready);
 
                 self.chunk = Some(Chunk { data, written: 0 });
 
@@ -133,9 +133,9 @@ impl Logic<Datagram, ()> for Udp {
             }
 
             LogicEvent::Forwarded(SubscriptionEvent::MioEvent(event)) => {
-                println!("sink got an mio event");
+                //println!("sink got an mio event");
                 if event.readiness().is_writable() {
-                    println!("is writable");
+                    //println!("is writable");
                     self.ready = true;
 
                     self.try_write(ctx)
@@ -145,10 +145,10 @@ impl Logic<Datagram, ()> for Udp {
             }
 
             LogicEvent::Forwarded(SubscriptionEvent::Ready(poll, token)) => {
-                println!("sink is ready");
+                //println!("sink is ready");
                 match self.socket {
                     Ok(ref socket) => {
-                        println!("registering the socket (token={})", token);
+                        //println!("registering the socket (token={})", token);
                         // @TODO expect doesn't seem appropriate
                         poll.register(socket, Token(token), Ready::writable(), PollOpt::edge())
                             .expect("pantomime bug: failed to register socket");
@@ -160,7 +160,7 @@ impl Logic<Datagram, ()> for Udp {
                     }
 
                     Err(ref _e) => {
-                        println!("ERRRR");
+                        //println!("ERRRR");
                         // shouldn't happen
 
                         ctx.unsubscribe(token);
@@ -173,9 +173,9 @@ impl Logic<Datagram, ()> for Udp {
             LogicEvent::Started => {
                 let actor_ref = ctx.stage_ref().actor_ref.clone();
 
-                println!("sink subscribing for id={}", actor_ref.id());
+                //println!("sink subscribing for id={}", actor_ref.id());
 
-                println!("messaging self");
+                //println!("messaging self");
 
                 ctx.subscribe(actor_ref);
 
@@ -184,7 +184,7 @@ impl Logic<Datagram, ()> for Udp {
 
             LogicEvent::Pulled => {
                 self.pulled = true;
-                println!("will pull");
+                //println!("will pull");
 
                 Action::Pull
             }

--- a/src/stream/source/mod.rs
+++ b/src/stream/source/mod.rs
@@ -5,19 +5,12 @@ use crate::stream::{Datagram, Logic, Stream};
 use std::iter::Iterator as Iter;
 use std::marker::PhantomData;
 
-mod iterator;
-mod merge;
-mod queue;
-mod repeat;
-mod single;
-mod udp;
-
-pub use iterator::Iterator;
-//pub use merge::Merge;
-//pub use queue::SourceQueue;
-pub use repeat::Repeat;
-pub use single::Single;
-pub use udp::Udp;
+pub mod iterator;
+pub mod merge;
+pub mod queue;
+pub mod repeat;
+pub mod single;
+pub mod udp;
 
 pub struct Source<A> {
     pub(in crate::stream) producers: Vec<LogicType<(), A>>,
@@ -48,22 +41,22 @@ where
     where
         I: 'static + Send,
     {
-        Self::new(Iterator::new(iterator))
+        Self::new(iterator::Iterator::new(iterator))
     }
 
-    //pub fn queue(capacity: usize) -> SourceQueue<A> {
-    //    SourceQueue::new(capacity)
-    //}
+    pub fn queue(capacity: usize) -> queue::SourceQueue<A> {
+        queue::SourceQueue::new(capacity)
+    }
 
     pub fn repeat(element: A) -> Self
     where
         A: Clone,
     {
-        Self::new(Repeat::new(element))
+        Self::new(repeat::Repeat::new(element))
     }
 
     pub fn single(element: A) -> Self {
-        Self::new(Single::new(element))
+        Self::new(single::Single::new(element))
     }
 
     pub fn to<Out>(self, sink: Sink<A, Out>) -> Stream<Out>
@@ -175,6 +168,6 @@ where
 
 impl Source<Datagram> {
     pub fn udp(socket: &mio::net::UdpSocket) -> Self {
-        Self::new(Udp::new(socket))
+        Self::new(udp::Udp::new(socket))
     }
 }

--- a/src/stream/source/udp.rs
+++ b/src/stream/source/udp.rs
@@ -78,14 +78,14 @@ impl Logic<(), Datagram> for Udp {
     ) -> Action<Datagram, Self::Ctl> {
         match msg {
             LogicEvent::Pulled => {
-                println!("got pulled");
+                //println!("got pulled");
                 self.waiting = true;
 
                 self.try_read()
             }
 
             LogicEvent::Forwarded(SubscriptionEvent::MioEvent(event)) => {
-                println!("source got a mio event");
+                //println!("source got a mio event");
                 if event.readiness().is_readable() {
                     self.ready = true;
 
@@ -96,7 +96,7 @@ impl Logic<(), Datagram> for Udp {
             }
 
             LogicEvent::Forwarded(SubscriptionEvent::Ready(poll, token)) => {
-                println!("source got a ready");
+                //println!("source got a ready");
                 match self.socket {
                     Ok(ref socket) => {
                         // @TODO expect doesn't seem appropriate
@@ -130,7 +130,7 @@ impl Logic<(), Datagram> for Udp {
             LogicEvent::Stopped => Action::None,
 
             LogicEvent::Cancelled => {
-                println!(" SOURCE CANCELLED!");
+                //println!(" SOURCE CANCELLED!");
                 if let Some(poll) = self.poll.take() {
                     if let Ok(ref socket) = self.socket {
                         // @TODO expect doesn't seem appropriate

--- a/src/stream/tests/mod.rs
+++ b/src/stream/tests/mod.rs
@@ -1,3 +1,4 @@
 mod context_stage_ref;
 mod legacy;
+mod queue;
 mod udp;

--- a/src/stream/tests/queue.rs
+++ b/src/stream/tests/queue.rs
@@ -1,0 +1,116 @@
+use crate::stream::*;
+
+#[test]
+fn test_basic() {
+    use crate::actor::*;
+    use std::io::{Error, ErrorKind};
+
+    struct TestReaper {
+        n: usize,
+    };
+
+    impl TestReaper {
+        fn new() -> Self {
+            Self { n: 0 }
+        }
+    }
+
+    impl Actor for TestReaper {
+        type Msg = Vec<usize>;
+
+        fn receive(&mut self, value: Self::Msg, ctx: &mut ActorContext<Self::Msg>) {
+            let sum: usize = value.iter().sum();
+
+            self.n += sum;
+
+            if self.n == 320 {
+                ctx.stop();
+            }
+        }
+
+        fn receive_signal(&mut self, signal: Signal, ctx: &mut ActorContext<Self::Msg>) {
+            if let Signal::Started = signal {
+                {
+                    let actor_ref = ctx.actor_ref().clone();
+
+                    ctx.schedule_thunk(Duration::from_secs(10), move || {
+                        actor_ref.fail(FailureError::new(Error::new(ErrorKind::Other, "failed")))
+                    });
+                }
+
+                let (queue_ref, queue_src) = ctx.spawn(Source::queue(16));
+
+                // @TODO test dropping behavior
+                queue_ref.push(10, ActorRef::empty());
+                queue_ref.push(20, ActorRef::empty());
+                queue_ref.push(30, ActorRef::empty());
+                queue_ref.complete();
+
+                let (stream_ref, result) = ctx.spawn(queue_src.map(|n| n * 2).to(Sink::collect()));
+
+                ctx.watch(result, |value| value);
+                ctx.watch(stream_ref, |_: StopReason| vec![200]);
+            }
+        }
+    }
+
+    assert!(ActorSystem::new().spawn(TestReaper::new()).is_ok());
+}
+
+#[test]
+fn test_drop_newest() {
+    use crate::actor::*;
+    use std::io::{Error, ErrorKind};
+
+    struct TestReaper {
+        n: usize,
+    };
+
+    impl TestReaper {
+        fn new() -> Self {
+            Self { n: 0 }
+        }
+    }
+
+    impl Actor for TestReaper {
+        type Msg = Vec<usize>;
+
+        fn receive(&mut self, value: Self::Msg, ctx: &mut ActorContext<Self::Msg>) {
+            let sum: usize = value.iter().sum();
+
+            self.n += sum;
+
+            if self.n == 320 {
+                ctx.stop();
+            }
+        }
+
+        fn receive_signal(&mut self, signal: Signal, ctx: &mut ActorContext<Self::Msg>) {
+            if let Signal::Started = signal {
+                {
+                    let actor_ref = ctx.actor_ref().clone();
+
+                    ctx.schedule_thunk(Duration::from_secs(10), move || {
+                        actor_ref.fail(FailureError::new(Error::new(ErrorKind::Other, "failed")))
+                    });
+                }
+
+                let (queue_ref, queue_src) = ctx
+                    .spawn(Source::queue(16).with_overflow_strategy(OverflowStrategy::DropNewest));
+
+                // @TODO test dropping behavior
+                queue_ref.push(10, ActorRef::empty());
+                queue_ref.push(20, ActorRef::empty());
+                queue_ref.push(30, ActorRef::empty());
+                queue_ref.complete();
+
+                let (stream_ref, result) = ctx.spawn(queue_src.map(|n| n * 2).to(Sink::collect()));
+
+                ctx.watch(result, |value| value);
+                ctx.watch(stream_ref, |_: StopReason| vec![200]);
+            }
+        }
+    }
+
+    assert!(ActorSystem::new().spawn(TestReaper::new()).is_ok());
+}


### PR DESCRIPTION
This commit adds an initial SourceQueue implementation. This allows
streams to be spawned, and separately elsewhere for items to be pushed
into the stream.

This initial commit is a rough cut -- it doesn't properly clean up, and
isn't ideal from a performance perspective. However, its interface is
defined well enough to allow testing in other applications to collect
feedback.

Fixes #69