### PR TITLE
streams: Implement FilterMap

### DIFF
--- a/src/stream/flow/filter_map.rs
+++ b/src/stream/flow/filter_map.rs
@@ -1,0 +1,38 @@
+use crate::stream::{Action, Logic, LogicEvent, StreamContext};
+
+pub struct FilterMap<F> {
+    filter_map: F,
+}
+
+impl<F> FilterMap<F> {
+    pub fn new(filter_map: F) -> Self {
+        Self { filter_map }
+    }
+}
+
+impl<A: Send, B: Send, F: FnMut(A) -> Option<B> + Send> Logic<A, B> for FilterMap<F> {
+    type Ctl = ();
+
+    fn name(&self) -> &'static str {
+        "FilterMap"
+    }
+
+    fn receive(
+        &mut self,
+        msg: LogicEvent<A, Self::Ctl>,
+        _: &mut StreamContext<A, B, Self::Ctl>,
+    ) -> Action<B, Self::Ctl> {
+        match msg {
+            LogicEvent::Pushed(element) => match (self.filter_map)(element) {
+                Some(element) => Action::Push(element),
+                None => Action::Pull,
+            },
+
+            LogicEvent::Pulled => Action::Pull,
+            LogicEvent::Cancelled => Action::Cancel,
+            LogicEvent::Stopped => Action::Complete(None),
+            LogicEvent::Started => Action::None,
+            LogicEvent::Forwarded(()) => Action::None,
+        }
+    }
+}

--- a/src/stream/flow/mod.rs
+++ b/src/stream/flow/mod.rs
@@ -5,6 +5,7 @@ use std::cell::RefCell;
 
 mod delay;
 mod filter;
+mod filter_map;
 mod fused;
 mod identity;
 mod map;
@@ -13,6 +14,7 @@ mod take_while;
 
 pub use self::delay::Delay;
 pub use self::filter::Filter;
+pub use self::filter_map::FilterMap;
 pub use self::identity::Identity;
 pub use self::map::Map;
 pub use self::scan::Scan;
@@ -139,6 +141,14 @@ where
         F: 'static + Send,
     {
         self.via(Flow::from_logic(Filter::new(filter)))
+    }
+
+    pub fn filter_map<C, F: FnMut(B) -> Option<C>>(self, filter_map: F) -> Flow<A, C>
+    where
+        C: 'static + Send,
+        F: 'static + Send,
+    {
+        self.via(Flow::from_logic(FilterMap::new(filter_map)))
     }
 
     pub fn map<C, F: FnMut(B) -> C>(self, map_fn: F) -> Flow<A, C>

--- a/src/stream/sink/udp.rs
+++ b/src/stream/sink/udp.rs
@@ -64,7 +64,7 @@ impl Udp {
                         }
                     }
 
-                    Err(e) if e.kind() == IoErrorKind::WouldBlock => {
+                    Err(ref e) if e.kind() == IoErrorKind::WouldBlock => {
                         //println!("would block");
                         self.ready = false;
 

--- a/src/stream/source/mod.rs
+++ b/src/stream/source/mod.rs
@@ -103,6 +103,14 @@ where
         self.via(Flow::from_logic(flow::Filter::new(filter)))
     }
 
+    pub fn filter_map<B, F: FnMut(A) -> Option<B>>(self, filter_map: F) -> Source<B>
+    where
+        B: 'static + Send,
+        F: 'static + Send,
+    {
+        self.via(Flow::from_logic(flow::FilterMap::new(filter_map)))
+    }
+
     pub fn map<B, F: FnMut(A) -> B>(self, map_fn: F) -> Source<B>
     where
         B: 'static + Send,

--- a/src/stream/source/udp.rs
+++ b/src/stream/source/udp.rs
@@ -38,7 +38,7 @@ impl Udp {
                         })
                     }
 
-                    Err(e) if e.kind() == IoErrorKind::WouldBlock => {
+                    Err(ref e) if e.kind() == IoErrorKind::WouldBlock => {
                         self.ready = false;
 
                         Action::None

--- a/src/stream/tests/flow/filter_map.rs
+++ b/src/stream/tests/flow/filter_map.rs
@@ -1,0 +1,32 @@
+#[test]
+fn test() {
+    use crate::actor::{Actor, ActorContext, ActorSystem, Signal};
+    use crate::stream::{Flow, Sink, Source};
+
+    struct TestReaper;
+
+    impl Actor for TestReaper {
+        type Msg = Vec<u32>;
+
+        fn receive(&mut self, msg: Self::Msg, ctx: &mut ActorContext<Self::Msg>) {
+            assert_eq!(msg, vec![17, 34, 51, 68, 85]);
+
+            ctx.stop();
+        }
+
+        fn receive_signal(&mut self, signal: Signal, ctx: &mut ActorContext<Self::Msg>) {
+            if let Signal::Started = signal {
+                let (_, result) = ctx.spawn(
+                    Source::iterator(1..=100)
+                        .filter_map(|n| if n % 17 == 0 { Some(n as u32) } else { None })
+                        .via(Flow::new().filter_map(Some))
+                        .to(Sink::collect()),
+                );
+
+                ctx.watch(result, |value| value);
+            }
+        }
+    }
+
+    assert!(ActorSystem::new().spawn(TestReaper).is_ok());
+}

--- a/src/stream/tests/flow/mod.rs
+++ b/src/stream/tests/flow/mod.rs
@@ -1,0 +1,1 @@
+mod filter_map;

--- a/src/stream/tests/mod.rs
+++ b/src/stream/tests/mod.rs
@@ -1,4 +1,5 @@
 mod context_stage_ref;
+mod flow;
 mod legacy;
 mod queue;
 mod udp;


### PR DESCRIPTION
This adds `Source::filter_map`, `Flow::filter_map`, and the accompanying
implementation.

`FilterMap` takes a function that both maps and filters by returning an
`Option<B>` when given an `A`.