### PR TITLE
streams: Implement MapConcat

### DIFF
--- a/src/stream/flow/map_concat.rs
+++ b/src/stream/flow/map_concat.rs
@@ -1,0 +1,62 @@
+use crate::stream::{Action, Logic, LogicEvent, StreamContext};
+
+pub struct MapConcat<I, F> {
+    map_concat: F,
+    iter: Option<I>,
+}
+
+impl<I, F> MapConcat<I, F> {
+    pub fn new(map_concat: F) -> Self {
+        Self {
+            map_concat,
+            iter: None,
+        }
+    }
+}
+
+impl<A: Send, B: Send, I: Iterator<Item = B>, F: FnMut(A) -> I + Send> Logic<A, B>
+    for MapConcat<I, F>
+where
+    I: 'static + Send,
+{
+    type Ctl = ();
+
+    fn name(&self) -> &'static str {
+        "MapConcat"
+    }
+
+    fn receive(
+        &mut self,
+        msg: LogicEvent<A, Self::Ctl>,
+        _: &mut StreamContext<A, B, Self::Ctl>,
+    ) -> Action<B, Self::Ctl> {
+        match msg {
+            LogicEvent::Pulled => match self.iter.as_mut().and_then(|ref mut iter| iter.next()) {
+                Some(el) => Action::Push(el),
+
+                None => Action::Pull,
+            },
+
+            LogicEvent::Pushed(element) => {
+                self.iter = Some((self.map_concat)(element));
+
+                // this only happens after we've pulled (per contract), so
+                // now it's time to push elements out
+
+                match self.iter.as_mut().and_then(|ref mut iter| iter.next()) {
+                    Some(el) => Action::Push(el),
+
+                    None => Action::Pull,
+                }
+            }
+
+            LogicEvent::Cancelled => Action::Cancel,
+
+            LogicEvent::Stopped => Action::Complete(None),
+
+            LogicEvent::Started => Action::None,
+
+            LogicEvent::Forwarded(()) => Action::None,
+        }
+    }
+}

--- a/src/stream/flow/mod.rs
+++ b/src/stream/flow/mod.rs
@@ -9,6 +9,7 @@ mod filter_map;
 mod fused;
 mod identity;
 mod map;
+mod map_concat;
 mod scan;
 mod take_while;
 
@@ -17,6 +18,7 @@ pub use self::filter::Filter;
 pub use self::filter_map::FilterMap;
 pub use self::identity::Identity;
 pub use self::map::Map;
+pub use self::map_concat::MapConcat;
 pub use self::scan::Scan;
 pub use self::take_while::TakeWhile;
 
@@ -157,6 +159,18 @@ where
         F: 'static + Send,
     {
         self.via(Flow::from_logic(Map::new(map_fn)))
+    }
+
+    pub fn map_concat<C, I: Iterator<Item = C>, F: FnMut(B) -> I + Send>(
+        self,
+        map_concat: F,
+    ) -> Flow<A, C>
+    where
+        C: 'static + Send,
+        F: 'static + Send,
+        I: 'static + Send,
+    {
+        self.via(Flow::from_logic(MapConcat::new(map_concat)))
     }
 }
 

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -12,6 +12,7 @@ pub mod source;
 
 pub use crate::stream::flow::Flow;
 pub use crate::stream::sink::Sink;
+pub use crate::stream::source::queue::QueueRef;
 pub use crate::stream::source::Source;
 
 mod internal;

--- a/src/stream/source/mod.rs
+++ b/src/stream/source/mod.rs
@@ -44,8 +44,8 @@ where
         Self::new(iterator::Iterator::new(iterator))
     }
 
-    pub fn queue(capacity: usize) -> queue::SourceQueue<A> {
-        queue::SourceQueue::new(capacity)
+    pub fn queue() -> queue::SourceQueue<A> {
+        queue::SourceQueue::new()
     }
 
     pub fn repeat(element: A) -> Self
@@ -117,6 +117,18 @@ where
         F: 'static + Send,
     {
         self.via(Flow::from_logic(flow::Map::new(map_fn)))
+    }
+
+    pub fn map_concat<B, I: Iterator<Item = B>, F: FnMut(A) -> I + Send>(
+        self,
+        map_concat: F,
+    ) -> Source<B>
+    where
+        B: 'static + Send,
+        F: 'static + Send,
+        I: 'static + Send,
+    {
+        self.via(Flow::from_logic(flow::MapConcat::new(map_concat)))
     }
 
     pub fn merge(self, source: Source<A>) -> Self {

--- a/src/stream/source/queue.rs
+++ b/src/stream/source/queue.rs
@@ -157,17 +157,31 @@ impl<A> SourceQueue<A>
 where
     A: 'static + Send,
 {
-    pub fn new(capacity: usize) -> Self {
+    pub fn new() -> Self {
         SourceQueue {
-            capacity,
+            capacity: 16,
             overflow_strategy: OverflowStrategy::DropOldest,
             phantom: PhantomData,
         }
     }
 
+    pub fn with_capacity(mut self, capacity: usize) -> Self {
+        self.capacity = capacity;
+        self
+    }
+
     pub fn with_overflow_strategy(mut self, strategy: OverflowStrategy) -> Self {
         self.overflow_strategy = strategy;
         self
+    }
+}
+
+impl<A> Default for SourceQueue<A>
+where
+    A: 'static + Send,
+{
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/stream/tests/flow/map_concat.rs
+++ b/src/stream/tests/flow/map_concat.rs
@@ -1,0 +1,33 @@
+#[test]
+fn test() {
+    use crate::actor::{Actor, ActorContext, ActorSystem, Signal};
+    use crate::stream::{Flow, Sink, Source};
+
+    struct TestReaper;
+
+    impl Actor for TestReaper {
+        type Msg = Vec<u32>;
+
+        fn receive(&mut self, msg: Self::Msg, ctx: &mut ActorContext<Self::Msg>) {
+            assert_eq!(msg, vec![10, 11, 12, 20, 21, 22, 30, 31, 32]);
+
+            ctx.stop();
+        }
+
+        fn receive_signal(&mut self, signal: Signal, ctx: &mut ActorContext<Self::Msg>) {
+            if let Signal::Started = signal {
+                let (_, result) = ctx.spawn(
+                    Source::iterator(1..=3)
+                        .map(|n| n * 10)
+                        .map_concat(|n| vec![n, n + 1, n + 2].into_iter())
+                        .via(Flow::new().map_concat(|n| vec![n].into_iter()))
+                        .to(Sink::collect()),
+                );
+
+                ctx.watch(result, |value| value);
+            }
+        }
+    }
+
+    assert!(ActorSystem::new().spawn(TestReaper).is_ok());
+}

--- a/src/stream/tests/flow/mod.rs
+++ b/src/stream/tests/flow/mod.rs
@@ -1,1 +1,2 @@
 mod filter_map;
+mod map_concat;

--- a/src/stream/tests/queue.rs
+++ b/src/stream/tests/queue.rs
@@ -38,7 +38,7 @@ fn test_basic() {
                     });
                 }
 
-                let (queue_ref, queue_src) = ctx.spawn(Source::queue(16));
+                let (queue_ref, queue_src) = ctx.spawn(Source::queue());
 
                 // @TODO test dropping behavior
                 queue_ref.push(10, ActorRef::empty());
@@ -95,8 +95,8 @@ fn test_drop_newest() {
                     });
                 }
 
-                let (queue_ref, queue_src) = ctx
-                    .spawn(Source::queue(16).with_overflow_strategy(OverflowStrategy::DropNewest));
+                let (queue_ref, queue_src) =
+                    ctx.spawn(Source::queue().with_overflow_strategy(OverflowStrategy::DropNewest));
 
                 // @TODO test dropping behavior
                 queue_ref.push(10, ActorRef::empty());


### PR DESCRIPTION
This adds `Flow::map_concat` and `Stream::map_concat` which takes a
function that consumes an `A` and produces an iterator of `B`s.

This `B`s are emitted serially until the iterator is exhausted, at which
point upstream is pulled for another element.

This can be used to e.g. turn a `Source<Vec<A>>` into a `Source<A>`.