### PR TITLE
streams: Implement Fold, and fix a bug in Fused

### DIFF
--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -28,7 +28,7 @@ impl Config {
             let mut map = HashMap::new();
 
             for (key, value) in defaults.iter() {
-                map.insert(key.to_string(), value.to_string());
+                map.insert((*key).to_string(), (*value).to_string());
             }
 
             map

--- a/src/mailbox/channel.rs
+++ b/src/mailbox/channel.rs
@@ -75,6 +75,7 @@ impl<M: 'static + Send> MailboxLogic<M> for CrossbeamChannelMailboxLogic<M> {
 }
 
 #[cfg(test)]
+#[allow(clippy::redundant_clone)]
 mod tests {
     use crate::mailbox::{CrossbeamChannelMailboxLogic, Mailbox};
     use std::thread;

--- a/src/mailbox/conqueue.rs
+++ b/src/mailbox/conqueue.rs
@@ -59,6 +59,7 @@ impl<M: 'static + Send> MailboxLogic<M> for ConqueueMailboxLogic<M> {
 }
 
 #[cfg(test)]
+#[allow(clippy::redundant_clone)]
 mod tests {
     use crate::mailbox::{ConqueueMailboxLogic, Mailbox};
     use std::thread;

--- a/src/mailbox/noop.rs
+++ b/src/mailbox/noop.rs
@@ -54,6 +54,7 @@ impl<M: Send + Sync + 'static> MailboxLogic<M> for NoopMailboxLogic<M> {
 }
 
 #[cfg(test)]
+#[allow(clippy::redundant_clone)]
 mod tests {
     use crate::mailbox::{Mailbox, NoopMailboxLogic};
 

--- a/src/mailbox/segqueue.rs
+++ b/src/mailbox/segqueue.rs
@@ -53,6 +53,7 @@ impl<M: 'static + Send> MailboxLogic<M> for CrossbeamSegQueueMailboxLogic<M> {
 }
 
 #[cfg(test)]
+#[allow(clippy::redundant_clone)]
 mod tests {
     use super::super::Mailbox;
     use super::*;

--- a/src/mailbox/vecdeque.rs
+++ b/src/mailbox/vecdeque.rs
@@ -66,6 +66,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::redundant_clone)]
 mod tests {
     use super::super::Mailbox;
     use super::*;

--- a/src/stream/flow/fold.rs
+++ b/src/stream/flow/fold.rs
@@ -1,0 +1,72 @@
+use crate::stream::{Action, Logic, LogicEvent, StreamContext};
+
+pub struct Fold<B, F> {
+    fold: F,
+    pulled: bool,
+    cancelled: bool,
+    last: Option<B>,
+}
+
+impl<B, F> Fold<B, F> {
+    pub fn new<A>(zero: B, fold: F) -> Self
+    where
+        F: FnMut(B, A) -> B,
+    {
+        Self {
+            fold,
+            pulled: false,
+            cancelled: false,
+            last: Some(zero),
+        }
+    }
+
+    fn take_last(&mut self) -> B {
+        self.last.take().expect("pantomime bug: Fold::last is None")
+    }
+}
+
+impl<A: Send, B: Send, F: FnMut(B, A) -> B + Send> Logic<A, B> for Fold<B, F> {
+    type Ctl = ();
+
+    fn name(&self) -> &'static str {
+        "Fold"
+    }
+
+    fn receive(
+        &mut self,
+        msg: LogicEvent<A, Self::Ctl>,
+        _: &mut StreamContext<A, B, Self::Ctl>,
+    ) -> Action<B, Self::Ctl> {
+        match msg {
+            LogicEvent::Pushed(element) => {
+                let last = self.take_last();
+                self.last = Some((self.fold)(last, element));
+                Action::Pull
+            }
+
+            LogicEvent::Pulled => {
+                self.pulled = true;
+                Action::Pull
+            }
+
+            LogicEvent::Cancelled => {
+                self.cancelled = true;
+                Action::Cancel
+            }
+
+            LogicEvent::Stopped => {
+                if self.pulled {
+                    Action::PushAndStop(self.take_last(), None)
+                } else if self.cancelled {
+                    Action::Stop(None)
+                } else {
+                    Action::None
+                }
+            }
+
+            LogicEvent::Started => Action::None,
+
+            LogicEvent::Forwarded(()) => Action::None,
+        }
+    }
+}

--- a/src/stream/flow/mod.rs
+++ b/src/stream/flow/mod.rs
@@ -6,6 +6,7 @@ use std::cell::RefCell;
 mod delay;
 mod filter;
 mod filter_map;
+mod fold;
 mod fused;
 mod identity;
 mod map;
@@ -16,6 +17,7 @@ mod take_while;
 pub use self::delay::Delay;
 pub use self::filter::Filter;
 pub use self::filter_map::FilterMap;
+pub use self::fold::Fold;
 pub use self::identity::Identity;
 pub use self::map::Map;
 pub use self::map_concat::MapConcat;
@@ -151,6 +153,14 @@ where
         F: 'static + Send,
     {
         self.via(Flow::from_logic(FilterMap::new(filter_map)))
+    }
+
+    pub fn fold<C, F: FnMut(C, B) -> C>(self, zero: C, fold_fn: F) -> Flow<A, C>
+    where
+        F: 'static + Send,
+        C: 'static + Clone + Send,
+    {
+        self.via(Flow::from_logic(Fold::new(zero, fold_fn)))
     }
 
     pub fn map<C, F: FnMut(B) -> C>(self, map_fn: F) -> Flow<A, C>

--- a/src/stream/internal/mod.rs
+++ b/src/stream/internal/mod.rs
@@ -649,7 +649,7 @@ where
             logic_actions: VecDeque::with_capacity(2),
             logic_pulled: false,
             buffer: VecDeque::with_capacity(buffer_size),
-            downstream: downstream.clone(),
+            downstream,
             state: StageState::Waiting(None),
             pulled: false,
             upstream_stopped: false,

--- a/src/stream/internal/mod.rs
+++ b/src/stream/internal/mod.rs
@@ -459,6 +459,7 @@ where
             Action::PushAndStop(el, reason) => {
                 //println!("{} Action::PushAndStop", self.logic.name());
                 self.receive_action(Action::Push(el), ctx);
+                //println!("did push");
                 self.receive_action(Action::Stop(reason), ctx);
             }
 

--- a/src/stream/sink/udp.rs
+++ b/src/stream/sink/udp.rs
@@ -171,7 +171,7 @@ impl Logic<Datagram, ()> for Udp {
             }
 
             LogicEvent::Started => {
-                let actor_ref = ctx.stage_ref().actor_ref.clone();
+                let actor_ref = ctx.stage_ref().actor_ref;
 
                 //println!("sink subscribing for id={}", actor_ref.id());
 

--- a/src/stream/source/mod.rs
+++ b/src/stream/source/mod.rs
@@ -111,6 +111,14 @@ where
         self.via(Flow::from_logic(flow::FilterMap::new(filter_map)))
     }
 
+    pub fn fold<B, F: FnMut(B, A) -> B>(self, zero: B, fold_fn: F) -> Source<B>
+    where
+        B: 'static + Send,
+        F: 'static + Send,
+    {
+        self.via(Flow::from_logic(flow::Fold::new(zero, fold_fn)))
+    }
+
     pub fn map<B, F: FnMut(A) -> B>(self, map_fn: F) -> Source<B>
     where
         B: 'static + Send,

--- a/src/stream/source/udp.rs
+++ b/src/stream/source/udp.rs
@@ -120,7 +120,7 @@ impl Logic<(), Datagram> for Udp {
             }
 
             LogicEvent::Started => {
-                let actor_ref = ctx.stage_ref().actor_ref.clone();
+                let actor_ref = ctx.stage_ref().actor_ref;
 
                 ctx.subscribe(actor_ref);
 

--- a/src/stream/tests/flow/fold.rs
+++ b/src/stream/tests/flow/fold.rs
@@ -1,0 +1,35 @@
+#[test]
+fn test() {
+    use crate::actor::{Actor, ActorContext, ActorSystem, Signal};
+    use crate::stream::{Flow, Sink, Source};
+
+    struct TestReaper;
+
+    impl Actor for TestReaper {
+        type Msg = Option<Vec<usize>>;
+
+        fn receive(&mut self, msg: Self::Msg, ctx: &mut ActorContext<Self::Msg>) {
+            assert_eq!(msg, Some(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]));
+
+            ctx.stop();
+        }
+
+        fn receive_signal(&mut self, signal: Signal, ctx: &mut ActorContext<Self::Msg>) {
+            if let Signal::Started = signal {
+                let (_, result) = ctx.spawn(
+                    Source::iterator(1..=10)
+                        .fold(Vec::new(), |mut a, n| {
+                            a.push(n);
+                            a
+                        })
+                        .via(Flow::new().fold(Vec::new(), |_, n| n))
+                        .to(Sink::first()),
+                );
+
+                ctx.watch(result, |value| value);
+            }
+        }
+    }
+
+    assert!(ActorSystem::new().spawn(TestReaper).is_ok());
+}

--- a/src/stream/tests/flow/mod.rs
+++ b/src/stream/tests/flow/mod.rs
@@ -1,2 +1,3 @@
 mod filter_map;
+mod fold;
 mod map_concat;


### PR DESCRIPTION
This implements fold, which is initialized with an initial state and a
function that takes the current state and next element, outputting the
next state.

Unlike scan, fold does not emit each state downstream, instead only
emitting a single element when upstream completes.

Additionally, this fixes a bug in Fused where logic could receive events
even after they emitted a stopped action.